### PR TITLE
chore: add CI workflow for PRs and main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: Lint, Typecheck, Format & Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "20.19.0"
+          cache: npm
+      - run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Typecheck
+        run: npm run typecheck
+      - name: Format check
+        run: npm run format:check
+      - name: Build
+        run: npm run build

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+build/
+.react-router/
+app/components/svg/

--- a/app/components/VolunteerCard.tsx
+++ b/app/components/VolunteerCard.tsx
@@ -38,9 +38,7 @@ export function VolunteerCard({
             </p>
           )}
           <p className="mt-4 text-lg text-gray-600">{description}</p>
-          {note && (
-            <p className="mt-2 text-sm italic text-gray-500">{note}</p>
-          )}
+          {note && <p className="mt-2 text-sm italic text-gray-500">{note}</p>}
         </div>
       </div>
 

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -46,11 +46,7 @@ function handleBotRequest(
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
       <NonceProvider value={nonce}>
-        <ServerRouter
-          context={routerContext}
-          url={request.url}
-          nonce={nonce}
-        />
+        <ServerRouter context={routerContext} url={request.url} nonce={nonce} />
       </NonceProvider>,
       {
         onAllReady() {
@@ -101,11 +97,7 @@ function handleBrowserRequest(
     let shellRendered = false;
     const { pipe, abort } = renderToPipeableStream(
       <NonceProvider value={nonce}>
-        <ServerRouter
-          context={routerContext}
-          url={request.url}
-          nonce={nonce}
-        />
+        <ServerRouter context={routerContext} url={request.url} nonce={nonce} />
       </NonceProvider>,
       {
         onShellReady() {

--- a/app/routes/admin.raffle.tsx
+++ b/app/routes/admin.raffle.tsx
@@ -158,10 +158,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   const authParam = url.searchParams.get("auth");
 
   if (authParam !== adminPassword) {
-    return Response.json(
-      { error: "Not authenticated." } satisfies ActionData,
-      { status: 403 },
-    );
+    return Response.json({ error: "Not authenticated." } satisfies ActionData, {
+      status: 403,
+    });
   }
 
   if (intent === "draw") {
@@ -238,16 +237,17 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       const errorMessage =
         error instanceof Error ? error.message : "An unknown error occurred";
       return Response.json(
-        { error: `Failed to draw winner: ${errorMessage}` } satisfies ActionData,
+        {
+          error: `Failed to draw winner: ${errorMessage}`,
+        } satisfies ActionData,
         { status: 500 },
       );
     }
   }
 
-  return Response.json(
-    { error: "Invalid intent." } satisfies ActionData,
-    { status: 400 },
-  );
+  return Response.json({ error: "Invalid intent." } satisfies ActionData, {
+    status: 400,
+  });
 };
 
 export default function RaffleAdmin() {

--- a/app/routes/artists_.signup.tsx
+++ b/app/routes/artists_.signup.tsx
@@ -40,8 +40,8 @@ export default function ArtistSignup() {
             <ContentSection title="Form">
               <p>
                 Thank you for your interest in Open Streets Tempe! Artist
-                signups have ended for this year&apos;s event. Check back next year
-                for new opportunities.
+                signups have ended for this year&apos;s event. Check back next
+                year for new opportunities.
               </p>
             </ContentSection>
           </div>

--- a/app/routes/volunteer.tsx
+++ b/app/routes/volunteer.tsx
@@ -47,9 +47,7 @@ const faqItems = [
           volunteer position for its specific schedule. We ask that you arrive
           15 minutes before your shift for check-in and a brief orientation.
         </p>
-        <p>
-          After your shift, you&apos;re free to enjoy the event!
-        </p>
+        <p>After your shift, you&apos;re free to enjoy the event!</p>
       </>
     ),
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "dev:svg": "run-s icons icons:watch",
     "dev": "run-p dev:*",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "react-router typegen && tsc",
     "optimize-images": "node scripts/optimize-images.js"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,5 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [
-    reactRouter(),
-    tsconfigPaths(),
-  ],
+  plugins: [reactRouter(), tsconfigPaths()],
 });


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow (`.github/workflows/ci.yml`) that runs lint, typecheck, format check, and build on PRs and pushes to main
- Actions pinned by SHA (`actions/checkout@v6.0.2`, `actions/setup-node@v6.3.0`) to prevent supply chain attacks
- Concurrency configured to cancel stale PR runs without canceling main branch pushes
- Add `format` and `format:check` npm scripts and `.prettierignore` for generated files
- Fix existing Prettier formatting drift in 6 files

## Test plan
- [x] `npm run lint` passes locally
- [x] `npm run typecheck` passes locally
- [x] `npm run format:check` passes locally
- [x] `npm run build` passes locally
- [x] CI workflow passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)