### PR TITLE
fix: skip husky in CI/Docker when not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "cross-env NODE_ENV=production node ./server.js",
     "typecheck": "react-router typegen && tsc",
     "optimize-images": "node scripts/optimize-images.js",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",


### PR DESCRIPTION
## Summary
- The `prepare` script runs `husky` during `npm ci`, but in Docker (`npm ci --omit=dev`) husky isn't installed since it's a devDependency, causing exit code 127
- Change `"prepare": "husky"` to `"prepare": "husky || true"` so it exits cleanly when unavailable

## Test plan
- [ ] Deploy workflow succeeds (Docker build passes `npm ci --omit=dev`)
- [ ] Local `npm install` still sets up husky hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build setup resilience by modifying the build preparation configuration to ensure the setup step completes successfully even when non-critical components encounter issues during the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->