### PR TITLE
feat: add Live Music, Live Art, and Vendors sections to home page

### DIFF
--- a/app/data/lineup.ts
+++ b/app/data/lineup.ts
@@ -1,0 +1,178 @@
+// Lineup data for Open Streets Tempe 2026.
+// Names were transcribed from the original promotional graphics —
+// please double-check spellings before publishing.
+
+export const liveArtArtists: string[] = [
+  "Allysa Wells",
+  "Andrea Pro",
+  "Brooke Shobe",
+  "Champ Styles",
+  "Dakota Drake",
+  "David Morgan",
+  "Izzy Brethour",
+  "K80",
+  "Kyllan Maney",
+  "LaLa Blue",
+  "Leilani Leilani",
+  "Marisa Skelpsa-Munoz",
+  "Martin Alcott",
+  "Nono the Artist",
+  "Rezmo",
+  "RJ Lopez",
+  "Slushiepunk",
+  "Such Styles",
+  "SYRE",
+  "Tracy Brown",
+  "Yukueone",
+];
+
+export interface MusicSet {
+  time: string;
+  artist: string;
+}
+
+export interface MusicStage {
+  name: string;
+  sets: MusicSet[];
+}
+
+// The Pedal Party at Pedal Haus stage is intentionally omitted here —
+// it has its own dedicated PedalPartySection on the home page.
+export const liveMusicStages: MusicStage[] = [
+  {
+    name: "Main Stage",
+    sets: [
+      { time: "10:30a", artist: "Schux Famicom" },
+      { time: "11:00a", artist: "SuperNormal" },
+      { time: "11:40a", artist: "Schux Famicom" },
+      { time: "12:00p", artist: "Cloudkickers" },
+      { time: "12:40p", artist: "Feral the DJ" },
+      { time: "1:00p", artist: "Boss Hectic" },
+      { time: "1:40p", artist: "Feral the DJ" },
+      { time: "2:00p", artist: "Juice the Sun" },
+      { time: "2:45p", artist: "Grupo Coatlicue" },
+    ],
+  },
+  {
+    name: "Busker Stage 1",
+    sets: [
+      { time: "10:30a", artist: "Peach Cinnamon" },
+      { time: "11:00a", artist: "Joe Giocinto" },
+      { time: "11:30a", artist: "Moon Squirrels" },
+      { time: "12:00p", artist: "Home Game" },
+      { time: "12:30p", artist: "Alaiza" },
+      { time: "1:00p", artist: "Chelle Naé" },
+      { time: "1:30p", artist: "Picasso Supreme" },
+      { time: "2:00p", artist: "Yessenia Reyna" },
+    ],
+  },
+  {
+    name: "Busker Stage 2",
+    sets: [
+      { time: "10:00a", artist: "DJ Gamabomb" },
+      { time: "10:45a", artist: "The End of History" },
+      { time: "11:30a", artist: "Electrxk Bloom" },
+      { time: "12:15p", artist: "Life on Standby" },
+      { time: "1:00p", artist: "The Terror Fx" },
+      { time: "2:00p", artist: "Orion Just Melted" },
+    ],
+  },
+  {
+    name: "Busker Stage 3",
+    sets: [
+      { time: "10:00a", artist: "El Sol JG the Sun" },
+      { time: "10:45a", artist: "Felix Moran" },
+      { time: "11:30a", artist: "Moon Zipper" },
+      { time: "12:15p", artist: "Eon Grey" },
+      { time: "1:00p", artist: "Ol' Man Fabel" },
+      { time: "2:00p", artist: "Felix Moran" },
+    ],
+  },
+  {
+    name: "Busker Stage 5",
+    sets: [
+      { time: "10:00a", artist: "Bree Cole" },
+      { time: "10:45a", artist: "Stratus the Fire" },
+      { time: "11:30a", artist: "Asphalt Astronaut" },
+      { time: "12:15p", artist: "Birdie Nichols" },
+      { time: "1:00p", artist: "Jessi Lawrence" },
+    ],
+  },
+];
+
+export const vendors: string[] = [
+  "AF Designs",
+  "Art With Kristie, LLC",
+  "Athena Mendez",
+  "Au-Rodriguez",
+  "Babey Pyrits",
+  "Biddy Areyo",
+  "Bike Saviors",
+  "Bogwitch Bobbles",
+  "Bozos Bineo",
+  "Burgess Greaway",
+  "C.A.S.S.",
+  "CAZCA Climbers",
+  "Casey Gibson",
+  "Cervantes",
+  "Chrissy Reesing",
+  "Craig Doxidi",
+  "The Cult of Chaos",
+  "Dani",
+  "Desert Botanical Garden",
+  "Desert Roots Kitchen",
+  "Diandra de Las Muertos",
+  "Enigma Arts",
+  "Eternal Noir Jewelry",
+  "Freakahaus Kraftz",
+  "Glenda Dria",
+  "Going Social Club Agency",
+  "Hannah Bismbrida",
+  "Hazel Flanagan",
+  "Hundred Foster Collective",
+  "Ice Pastel",
+  "InTheCut Opportunity Shop",
+  "Jam Works",
+  "James Fry",
+  "Jenky Clothes",
+  "Jerome Mann",
+  "Jesus Lizarraga",
+  "Judith Avon",
+  "Karen Soelens Creations",
+  "Kelp Toad",
+  "Kimberly Mina",
+  "Lady Salas",
+  "Laura Wojciechowicz",
+  "Lily Wilks",
+  "Luzel Bona",
+  "Macy Porter",
+  "Manuel Gomez",
+  "Megan Esry",
+  "Miki Rose",
+  "Miranda Isabella",
+  "Morgan Lindsay",
+  "Naked Sheep Knits",
+  "NON Couture",
+  "Oahh Ish Creations",
+  "Paula-Marie Benes",
+  "Penny Threebawrs",
+  "Petite Sweets",
+  "Prescription Love Coffee",
+  "Rabbits on Chala",
+  "Rae Wilson",
+  "Ray Kennedy",
+  "Richard Bagovera",
+  "Sad Vamp Ceramics",
+  "Sams",
+  "Scott Garcer",
+  "Sebatie Customs",
+  "Sharlie Singer",
+  "Shelby Smith",
+  "Smora James",
+  "Tabby Kilo",
+  "Teena Mama",
+  "Tempe History Museum",
+  "tetikomban.com",
+  "Vacaran Remots",
+  "Zachartah Oldhem",
+];

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,6 +6,7 @@ import { motion, AnimatePresence } from "motion/react";
 import { type ThemeColor, useTheme } from "~/components/ThemeProvider";
 import { Container } from "~/components/Container";
 import { eventData, eventJsonLd } from "~/data/event";
+import { liveArtArtists, liveMusicStages, vendors } from "~/data/lineup";
 import { generateMetaTags, generateFaviconLinks } from "~/utils/meta";
 import { FadeIn } from "~/components/FadeIn";
 import { CalendarIcon, MapPinIcon } from "@heroicons/react/24/outline";
@@ -449,6 +450,124 @@ function PedalPartySection() {
   );
 }
 
+function SectionHeading({
+  title,
+  lead,
+  titleColor,
+}: {
+  title: string;
+  lead: string;
+  titleColor: string;
+}) {
+  return (
+    <div className="mx-auto mb-8 max-w-2xl text-center">
+      <h2
+        className={`font-display text-3xl font-bold sm:text-4xl ${titleColor}`}
+      >
+        {title}
+      </h2>
+      <p className="mt-3 text-lg text-gray-600">{lead}</p>
+    </div>
+  );
+}
+
+function LiveMusicSection() {
+  return (
+    <div className="bg-white pb-16 pt-8">
+      <Container>
+        <FadeIn>
+          <div className="mx-auto max-w-6xl">
+            <SectionHeading
+              title="Live Music"
+              lead="Five free stages of local talent fill the streets all afternoon, from busker corners to a full main stage program."
+              titleColor="text-eggplant-900"
+            />
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {liveMusicStages.map((stage) => (
+                <div
+                  key={stage.name}
+                  className="rounded-2xl border-4 border-eggplant-200 bg-white p-6 shadow-sm"
+                >
+                  <h3 className="mb-4 border-b-4 border-eggplant-100 pb-3 font-display text-xl font-bold text-eggplant-900">
+                    {stage.name}
+                  </h3>
+                  <ul className="space-y-2">
+                    {stage.sets.map((set) => (
+                      <li
+                        key={`${stage.name}-${set.time}-${set.artist}`}
+                        className="flex items-baseline gap-4 text-lg"
+                      >
+                        <span className="w-20 shrink-0 font-semibold tabular-nums text-eggplant-700">
+                          {set.time}
+                        </span>
+                        <span className="text-gray-800">{set.artist}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          </div>
+        </FadeIn>
+      </Container>
+    </div>
+  );
+}
+
+function LiveArtSection() {
+  return (
+    <div className="bg-white pb-16 pt-8">
+      <Container>
+        <FadeIn>
+          <div className="mx-auto max-w-6xl">
+            <SectionHeading
+              title="Live Art"
+              lead="Watch local artists create murals, paintings, and installations live throughout the route."
+              titleColor="text-apricot-700"
+            />
+            <div className="rounded-2xl border-4 border-apricot-200 bg-white p-6 shadow-sm sm:p-8">
+              <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
+                {liveArtArtists.map((artist) => (
+                  <div key={artist} className="text-lg text-gray-800">
+                    {artist}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </FadeIn>
+      </Container>
+    </div>
+  );
+}
+
+function VendorsSection() {
+  return (
+    <div className="bg-white pb-16 pt-8">
+      <Container>
+        <FadeIn>
+          <div className="mx-auto max-w-6xl">
+            <SectionHeading
+              title="Vendors & Booths"
+              lead="Browse handmade goods, art, food, and community organizations from across the Valley. Bring cash and an empty tote."
+              titleColor="text-tachi-900"
+            />
+            <div className="rounded-2xl border-4 border-tachi-200 bg-white p-6 shadow-sm sm:p-8">
+              <div className="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3 lg:grid-cols-4">
+                {vendors.map((vendor) => (
+                  <div key={vendor} className="text-lg text-gray-800">
+                    {vendor}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </FadeIn>
+      </Container>
+    </div>
+  );
+}
+
 function PartnersSection() {
   const theme = useTheme();
 
@@ -576,6 +695,9 @@ export default function Index() {
         <MainContent />
         <BikeParadeSection />
         <PedalPartySection />
+        <LiveMusicSection />
+        <LiveArtSection />
+        <VendorsSection />
         <PartnersSection />
         <ThemedSection inverse>
           <Container>


### PR DESCRIPTION
## Summary
- Replaces the three flat 2026-live-art / 2026-live-music / 2026-vendors promotional images with structured content sections rendered from `app/data/lineup.ts`, so the lineup can be edited as text and stays consistent with the rest of the page typography.
- Adds a shared `SectionHeading` helper used by all three new sections for consistent title + lead treatment.
- Live Music renders five identical stage cards (Main Stage just appears first in the data); Live Art and Vendors share the same `grid-cols-2 sm:grid-cols-3 lg:grid-cols-4` layout. Borders are `border-4` to match the footer's divider weight.
- All times standardized to `H:MMa`/`H:MMp`. Vendors merged into one alphabetized list of 74 entries.
- Deletes the now-unused 2026 promo PNGs from `public/images/` and `public/images/originals/`.

## Test plan
- [ ] Visual check of `/` at mobile (375px), tablet (768px), and desktop (1280px+) widths
- [ ] Verify Live Music card grid wraps correctly: 1 col mobile → 2 col tablet → 3 col desktop
- [ ] Verify Live Art and Vendors grids match: 2 col mobile → 3 col tablet → 4 col desktop
- [ ] Confirm all music times render at consistent width (`w-20`) without wrapping
- [ ] Confirm section spacing rhythm matches the existing Bike Parade and Pedal Party sections above
- [ ] Spot-check artist and vendor name spellings against source — see notes below

## Notes for reviewer
- **Vendor and artist names** were transcribed from the original promotional graphics. Several were hard to read clearly — please verify against the source list before merging. The data file has a comment at the top noting this.
- **Music schedule oddities** preserved as-is from the source graphic: `Schux Famicom` and `Feral the DJ` each appear twice on Main Stage; `Felix Moran` appears twice on Busker Stage 3; the source jumps from Busker Stage 3 to Busker Stage 5 (no Stage 4).
- The Pedal Party at Pedal Haus stage is intentionally **not** in `liveMusicStages` — it already has its own `PedalPartySection` directly above with the angled photo and lineup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
  * Added live music schedule section displaying multiple performance stages with artist lineups and set times
  * Added live art performers section
  * Added event vendors listing section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->